### PR TITLE
refactored profile/code for readability. test for get_profile's failing

### DIFF
--- a/dna/test/index.js
+++ b/dna/test/index.js
@@ -24,7 +24,7 @@ const conductorConfig = Config.gen(
     // to instantiate a sim2h_server
     network: {
       type: 'sim2h',
-      sim2h_url: 'ws://localhost:8888',
+      sim2h_url: 'ws://localhost:9000',
     },
   })
 
@@ -50,11 +50,11 @@ orchestrator.registerScenario("call create_profile then get_profile", async (s, 
   // Make a call to a Zome function create_profile
   // indicating the function, and passing it the argument
   // FROM TATS: the first argument is the nickname I assigned in line 13. then zome name then zome call name.
-  const profile_addr = await alice.call("kizuna_dna", "profile", "create_profile", {
-    first_name : "tatsuya",
-    last_name: "sato",
-    email: "tatsuya.g.sato@gmail.com"
-  })
+  const profile_addr = await alice.call("kizuna_dna", "profile", "create_profile", {"profile_input" : {
+    "first_name":"tatsuya",
+    "last_name":"sato",
+    "email":"tatsuya.g.sato@gmail.com"
+  }})
 
   // TATS: check if the profile_addr returns Ok from rust
   t.ok(profile_addr.Ok)
@@ -64,9 +64,12 @@ orchestrator.registerScenario("call create_profile then get_profile", async (s, 
 
   // TATS: now, let's try to get the entry content created with the result_create_profile with bob using get_profile call
   // the profile_addr.Ok contains the address of the profile entry committed since create_profile returns the addr of the committed entry. 
-  const result = await bob.call("kizuna_dna", "profile", "get_profile", {"address": profile_addr.Ok})
+  const result = await bob.call("kizuna_dna", "profile", "get_profile", {"id": profile_addr.Ok})
+  // const list_result = await bob.call("kizuna_dna", "profile", "list_notes", {})
 
   // check for equality of the actual and expected results
+  // t.deepEqual(list_result.Ok.length, 1)
+  // failing right now
   t.deepEqual(result, { Ok: { App: [ 'Profile', '{"first_name": "tatsuya", "last_name": "sato", "email": "tatsuya.g.sato@gmail.com"}' ] } })
 })
 

--- a/dna/zomes/profile/code/src/lib.rs
+++ b/dna/zomes/profile/code/src/lib.rs
@@ -1,73 +1,20 @@
 #![feature(proc_macro_hygiene)]
 // #[allow(dead_code)]
 
-// use hdk::prelude::*'
+use hdk::prelude::*;
 use hdk_proc_macros::zome;
-use holochain_anchors::anchor;
+use serde_derive::{Deserialize, Serialize};
 use hdk::{
-    self,
-    entry,
-    from,
-    link,
     entry_definition::ValidatingEntryType,
-    holochain_core_types::{
-        dna::entry_types::Sharing,
-    },
-    holochain_json_api::{
-        json::JsonString,
-        error::JsonError,
-    },
-    prelude::*,
+    error::ZomeApiResult,
     holochain_persistence_api::cas::content::Address
 };
 
+use crate::profile::ProfileEntry;
+use crate::profile::Profile;
+pub mod profile;
+
 // see https://developer.holochain.org/api/0.0.42-alpha5/hdk/ for info on using the hdk library
-
-const PROFILE_ENTRY_NAME: &str = "profile";
-const PROFILE_LINK_TYPE: &str = "profile_link";
-const PROFILES_ANCHOR_TYPE: &str = "profiles";
-const PROFILES_ANCHOR_TEXT: &str = "profiles";
-
-#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
-#[serde(rename_all = "snake_case")]
-pub struct Profile {
-    id: Address,
-    first_name: String,
-    last_name: String,
-    email: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
-#[serde(rename_all = "snake_case")]
-pub struct ProfileEntry {
-    first_name: String,
-    last_name: String,
-    email: String,
-}
-
-impl Profile {
-    pub fn new(id: Address, profile_input: ProfileEntry) ->  ZomeApiResult<Profile> {
-        Ok(Profile {
-            id: id.clone(),
-            first_name: profile_input.first_name,
-            last_name: profile_input.last_name,
-            email: profile_input.email
-        })
-    }
-
-    // pub fn entry(profile_input: ProfileEntry) -> ZomeApiResult<Entry> {
-    //     Entry::App(PROFILE_ENTRY_NAME.into(), profile_input.clone().into())
-    // }
-
-    // pub fn profile_from_entry(entry_input: Entry) -> ZomeApiResult<Profile> {
-    //     Ok(Profile {
-    //         id: Entry.address.clone(),
-    //         first_name: entry_input.first_name,
-    //         second_name: entry_input.last_name,
-    //         email: entry_input.email
-    //     })
-    // }
-}
 
 #[zome]
 mod profile_zome {
@@ -83,67 +30,32 @@ mod profile_zome {
     }
 
     #[entry_def]
-    fn definition() -> ValidatingEntryType {
-        entry!(
-            name: PROFILE_ENTRY_NAME,
-            description: "this is the profile spec of the user",
-            sharing: Sharing::Public,
-            validation_package: || {
-                hdk::ValidationPackageDefinition::Entry
-            },
-            validation: | _validation_data: hdk::EntryValidationData<ProfileEntry>| {
-                Ok(())
-            },
-            links: [
-                from!(
-                    holochain_anchors::ANCHOR_TYPE,
-                    link_type: PROFILE_LINK_TYPE,
-                    validation_package: || {
-                        hdk::ValidationPackageDefinition::Entry
-                    },
-                    validation: | _validation_data: hdk::LinkValidationData | {
-                        Ok(())
-                    }
-                )
-            ]
-        )
+    fn profile_def() -> ValidatingEntryType {
+        profile::definition()
     }
+
 
     #[entry_def]
     fn anchor_def() ->ValidatingEntryType {
         holochain_anchors::anchor_definition()
     }
 
-    fn profiles_anchor() -> ZomeApiResult<Address> {
-        anchor(PROFILES_ANCHOR_TYPE.to_string(), PROFILES_ANCHOR_TEXT.to_string())
-    }
-
     #[zome_fn("hc_public")]
     fn create_profile(profile_input: ProfileEntry) -> ZomeApiResult<Profile> {
-        // let new_profile_entry = Profile::entry(profile_input);
-        let new_profile_entry = Entry::App(PROFILE_ENTRY_NAME.into(), profile_input.clone().into());
-        let address = hdk::commit_entry(&new_profile_entry)?;
-        hdk::link_entries(&profiles_anchor()?, &address, PROFILE_LINK_TYPE, "")?;
-        Profile::new(address, profile_input)
+        profile::handlers::create_profile(profile_input)
     }
 
-    // #[zome_fn("hc_public")]
-    pub fn get_profile(id: Address) -> ZomeApiResult<Profile> {
-        let entry: ProfileEntry = hdk::utils::get_as_type(id.clone())?; //returns type result
-        Profile::new(id, entry)
+
+    #[zome_fn("hc_public")]
+    fn get_profile(id: Address) -> ZomeApiResult<Option<Entry>>  {
+        // profile::handlers::get_profile(id)
+        hdk::get_entry(&id)
     }
+
     
     #[zome_fn("hc_public")]
     fn list_profiles() -> ZomeApiResult<Vec<Profile>> {
-        hdk::get_links_and_load(&profiles_anchor()?, LinkMatch::Exactly(PROFILE_LINK_TYPE), LinkMatch::Any)
-            .map(|profile_list|{
-                profile_list.into_iter()
-                    .filter_map(Result::ok)
-                    .flat_map(|entry| {
-                        let id = entry.address();
-                        hdk::debug(format!("list_entry{:?}", entry)).ok();
-                        get_profile(id)
-                    }).collect()
-            })
+        profile::handlers::list_profiles()
     }
+
 }

--- a/dna/zomes/profile/code/src/profile/handlers.rs
+++ b/dna/zomes/profile/code/src/profile/handlers.rs
@@ -1,0 +1,48 @@
+use hdk::{
+    error::ZomeApiResult,
+    holochain_persistence_api::cas::content::{
+        Address,
+        AddressableContent
+    },
+    prelude::*,
+};
+use holochain_anchors::anchor;
+use crate::profile::{
+    ProfileEntry,
+    Profile,
+    PROFILE_LINK_TYPE,
+    PROFILES_ANCHOR_TYPE, 
+    PROFILES_ANCHOR_TEXT
+};
+
+fn profiles_anchor() -> ZomeApiResult<Address> {
+    anchor(PROFILES_ANCHOR_TYPE.to_string(), PROFILES_ANCHOR_TEXT.to_string())
+}
+
+pub fn create_profile(profile_input: ProfileEntry) -> ZomeApiResult<Profile> {
+    // let new_profile_entry = Profile::entry(profile_input);
+    let new_profile_entry = Profile::entry(profile_input.clone());
+    // let new_profile_entry = Entry::App(PROFILE_ENTRY_NAME.into(), profile_input.clone().into());
+    let address = hdk::commit_entry(&new_profile_entry)?;
+    hdk::link_entries(&profiles_anchor()?, &address, PROFILE_LINK_TYPE, "")?;
+    Profile::new(address, profile_input)
+}
+
+pub fn get_profile(id: Address) -> ZomeApiResult<Profile> {
+    let entry: ProfileEntry = hdk::utils::get_as_type(id.clone())?; //returns type result
+    Profile::new(id, entry)
+}
+
+pub fn list_profiles() -> ZomeApiResult<Vec<Profile>> {
+    // needs to be updated to solve hot spots
+    hdk::get_links_and_load(&profiles_anchor()?, LinkMatch::Exactly(PROFILE_LINK_TYPE), LinkMatch::Any)
+        .map(|profile_list|{
+            profile_list.into_iter()
+                .filter_map(Result::ok)
+                .flat_map(|entry| {
+                    let id = entry.address();
+                    hdk::debug(format!("list_entry{:?}", entry)).ok();
+                    get_profile(id)
+                }).collect()
+        })
+}

--- a/dna/zomes/profile/code/src/profile/mod.rs
+++ b/dna/zomes/profile/code/src/profile/mod.rs
@@ -1,0 +1,92 @@
+use serde_derive::{Deserialize, Serialize};
+use holochain_json_derive::DefaultJson; 
+use hdk::{
+    self,
+    entry,
+    from,
+    link,
+    entry_definition::ValidatingEntryType,
+    holochain_core_types::{
+        dna::entry_types::Sharing,
+    },
+    holochain_json_api::{
+        json::JsonString,
+        error::JsonError,
+    },
+    prelude::*,
+    holochain_persistence_api::cas::content::Address
+};
+
+pub mod handlers;
+
+const PROFILE_ENTRY_NAME: &str = "profile";
+const PROFILE_LINK_TYPE: &str = "profile_link";
+const PROFILES_ANCHOR_TYPE: &str = "profiles";
+const PROFILES_ANCHOR_TEXT: &str = "profiles";
+
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
+// #[serde(rename_all = "snake_case")]
+pub struct Profile {
+    id: Address,
+    first_name: String,
+    last_name: String,
+    email: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, DefaultJson, Clone)]
+// #[serde(rename_all = "snake_case")]
+pub struct ProfileEntry {
+    first_name: String,
+    last_name: String,
+    email: String,
+}
+
+impl Profile {
+    pub fn new(id: Address, profile_input: ProfileEntry) ->  ZomeApiResult<Profile> {
+        Ok(Profile {
+            id,
+            first_name: profile_input.first_name,
+            last_name: profile_input.last_name,
+            email: profile_input.email
+        })
+    }
+
+    pub fn entry(profile_input: ProfileEntry) -> Entry {
+        Entry::App(PROFILE_ENTRY_NAME.into(), profile_input.into())
+    }
+
+    // pub fn profile_from_entry(entry_input: Entry) -> ZomeApiResult<Profile> {
+    //     Ok(Profile {
+    //         id: Entry.address.clone(),
+    //         first_name: entry_input.first_name,
+    //         second_name: entry_input.last_name,
+    //         email: entry_input.email
+    //     })
+    // }
+}
+
+pub fn definition() -> ValidatingEntryType {
+    entry!(
+        name: PROFILE_ENTRY_NAME,
+        description: "this is the profile spec of the user",
+        sharing: Sharing::Public,
+        validation_package: || {
+            hdk::ValidationPackageDefinition::Entry
+        },
+        validation: | _validation_data: hdk::EntryValidationData<ProfileEntry>| {
+            Ok(())
+        },
+        links: [
+            from!(
+                holochain_anchors::ANCHOR_TYPE,
+                link_type: PROFILE_LINK_TYPE,
+                validation_package: || {
+                    hdk::ValidationPackageDefinition::Entry
+                },
+                validation: | _validation_data: hdk::LinkValidationData | {
+                    Ok(())
+                }
+            )
+        ]
+    )
+}


### PR DESCRIPTION
refactored the project patterning it with the react-graphqk-template.
test is failing for get_profile with this output from tryorama

```
06:11:51 [tryorama: tryorama conductor bob] debug: -> {
  SerializationError: 'invalid type: map, expected a string at line 1 column 6'
}
not ok 2 should be equivalent`
    operator: deepEqual
    expected: |-
      { Ok: { App: [ 'Profile', '{"first_name": "tatsuya", "last_name": "sato", "email": "tatsuya.g.sato@gmail.com"}' ] } }
    actual: |-
      { SerializationError: 'invalid type: map, expected a string at line 1 column 6' }
    stack: |-
      Error: should be equivalent
          at Test.assert [as _assert] (/Users/lc/Desktop/Kizuna-old-forked/dna/test/node_modules/tape/lib/test.js:228:54)
          at Test.bound [as _assert] (/Users/lc/Desktop/Kizuna-old-forked/dna/test/node_modules/tape/lib/test.js:80:32)
          at Test.tapeDeepEqual (/Users/lc/Desktop/Kizuna-old-forked/dna/test/node_modules/tape/lib/test.js:426:10)
          at Test.bound [as deepEqual] (/Users/lc/Desktop/Kizuna-old-forked/dna/test/node_modules/tape/lib/test.js:80:32)
          at /Users/lc/Desktop/Kizuna-old-forked/dna/test/index.js:72:5
          at processTicksAndRejections (internal/process/task_queues.js:93:5)
```